### PR TITLE
feat(browserAction/alarms): add the complete APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ TypeScript type definitions for WebExtensions
 :warning: This is in a WIP state. :warning:
 
 What is implemented:
+- `browserAction`
 - `commands`
 - `events`
 - `omnibox`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ TypeScript type definitions for WebExtensions
 :warning: This is in a WIP state. :warning:
 
 What is implemented:
+- `alarms`
 - `browserAction`
 - `commands`
 - `events`

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -22,6 +22,35 @@ interface EvListener<T extends Function> {
 
 type Listener<T> = EvListener<(arg: T) => void>;
 
+declare namespace browser.browserAction {
+    type ColorArray = [number, number, number, number];
+    type ImageDataType = ImageData;
+
+    function setTitle(details: { title: string, tabId?: number }): void;
+    function getTitle(details: { tabId?: number }): Promise<string>;
+
+    type IconViaPath = {
+        path: string | object,
+        tabId?: number,
+    };
+
+    type IconViaImageData = {
+        imageData: ImageDataType,
+        tabId?: number,
+    };
+    function setIcon(details: IconViaPath | IconViaImageData): Promise<void>;
+    function setPopup(details: { popup: string, tabId?: number }): void;
+    function getPopup(details: { tabId?: number }): Promise<string>;
+    function setBadgeText(details: { text: string, tabId?: number }): void;
+    function getBadgeText(details: { tabId?: number }): Promise<string>;
+    function setBadgeBackgroundColor(details: { color: string|ColorArray, tabId?: number }): void;
+    function getBadgeBackgroundColor(details: { tabId?: number }): Promise<ColorArray>;
+    function enable(tabId?: number): void;
+    function disable(tabId?: number): void;
+
+    const onClicked: Listener<browser.tabs.Tab>;
+}
+
 declare namespace browser.commands {
     type Command = {
         name?: string,

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -22,6 +22,30 @@ interface EvListener<T extends Function> {
 
 type Listener<T> = EvListener<(arg: T) => void>;
 
+declare namespace browser.alarms {
+    type Alarm = {
+        name: string,
+        scheduledTime: number,
+        periodInMinutes?: number,
+    };
+
+    type When = {
+        when?: number,
+        periodInMinutes?: number,
+    };
+    type DelayInMinutes = {
+        delayInMinutes?: number,
+        periodInMinutes?: number,
+    };
+    function create(name?: string, alarmInfo?: When | DelayInMinutes): void;
+    function get(name?: string): Promise<Alarm|undefined>;
+    function getAll(): Promise<Alarm[]>;
+    function clear(name?: string): Promise<boolean>;
+    function clearAll(): Promise<boolean>;
+
+    const onAlarm: Listener<Alarm>;
+}
+
 declare namespace browser.browserAction {
     type ColorArray = [number, number, number, number];
     type ImageDataType = ImageData;


### PR DESCRIPTION
### feat(browserAction): add the complete API      
 
No missing feature in this API compared to chromium

### feat(alarms): add the complete API

Once again, feature parity for FF/Chrome