### PR TITLE
feat(sidebarAction): add the entire API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Almost everything is implemented:
 - `omnibox`
 - `pageAction`
 - `runtime`
+- `sidebarAction`
 - `storage`
 - `tabs`
 - `topSites`

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -753,6 +753,30 @@ declare namespace browser.runtime {
     const onMessage: EvListener<onMessageEvent>;
 }
 
+declare namespace browser.sidebarAction {
+    type ImageDataType = ImageData;
+
+    function setPanel(details: { panel: string, tabId?: number }): void;
+
+    function getPanel(details: { tabId?: number }): Promise<string>;
+
+    function setTitle(details: { title: string, tabId?: number }): void;
+
+    function getTitle(details: { tabId?: number }): Promise<string>;
+
+    type IconViaPath = {
+        path: string | { [index: number]: string },
+        tabId?: number,
+    };
+
+    type IconViaImageData = {
+        imageData: ImageDataType | { [index: number]: ImageDataType },
+        tabId?: number,
+    };
+
+    function setIcon(details: IconViaPath | IconViaImageData): Promise<void>;
+}
+
 declare namespace browser.storage {
     type StorageArea = {
         get: (keys: string|string[]|object|null) => Promise<object>,


### PR DESCRIPTION
Creating some non existing types to enforce more strictness in the
`setIcon()` sidebar action

Small API as most of it functionality is based on manifest fields
rather than being active

Warning: This API will be available in Firefox 54. It is already
available in the nightly/dev channel, and is offered so that extension
developers can start working with it before the mainstream release