### PR TITLE
chore(yarn): publication of a new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,6 @@
 
 TypeScript type definitions for WebExtensions
 
-Almost everything is implemented:
-- `alarms`
-- `bookmarks`
-- `browserAction`
-- `browsingData`
-- `commands`
-- `contextMenus`
-- `contextualIdentities`
-- `cookies`
-- `downloads`
-- `events`
-- `extension`
-- `extensionTypes`
-- `history`
-- `i18n`
-- `identity`
-- `idle`
-- `management`
-- `notifications`
-- `omnibox`
-- `pageAction`
-- `runtime`
-- `sidebarAction`
-- `storage`
-- `tabs`
-- `topSites`
-- `webNavigation`
-- `webRequest`, partly
-- `windows`
-
 ## Requirements
 
 As this library is using the `object` type, `typescript` should at least be on
@@ -74,6 +44,11 @@ option.
   }
 }
 ```
+
+## Completion status
+
+The API is fully implemented aside from `browser.webRequest`, which is still in
+progress. This is based on MDN's documentation.
 
 [build-badge]: https://travis-ci.org/michael-zapata/web-ext-types.svg?branch=master
 [build-url]: https://travis-ci.org/michael-zapata/web-ext-types

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web-ext-types",
     "author": "Michael Zapata <michael.zapata@scality.com> (https://github.com/michael-zapata)",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "TypeScript type definitions for WebExtensions",
     "keywords": ["firefox", "typescript", "webextension"],
     "repository": "michael-zapata/web-ext-types",


### PR DESCRIPTION
### docs(README): make things more readable

The API is pretty much complete, no need to put the status on top of
the README, nor is it needed to explicitely show every supported API

### chore(yarn): upgrade version number

Patch number, as this only brought a new API while we're still under
version 1