### PR TITLE
fix(extensionTypes): optional InjectDetails fields

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -470,9 +470,9 @@ declare namespace browser.extensionTypes {
         allFrames?: boolean,
         code?: string,
         file?: string,
-        frameId: number,
-        // unsupported: matchAboutBlank: boolean,
-        runAt: RunAt,
+        frameId?: number,
+        // unsupported: matchAboutBlank?: boolean,
+        runAt?: RunAt,
     };
 }
 


### PR DESCRIPTION
As per MDN's documentation https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/extensionTypes/InjectDetails