### PR TITLE
feat(apis): update with the new FF54(beta) release

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1018,6 +1018,16 @@ declare namespace browser.webNavigation {
 
     const onCommited: TransitionNavListener;
 
+    const onCreatedNavigationTarget: NavListener<{
+        sourceFrameId: number,
+        // Unsupported: sourceProcessId: number,
+        sourceTabId: number,
+        tabId: number,
+        timeStamp: number,
+        url: string,
+        windowId: number,
+    }>;
+
     const onDOMContentLoaded: DefaultNavListener;
 
     const onCompleted: DefaultNavListener;

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -732,11 +732,11 @@ declare namespace browser.runtime {
     // const onSuspend: Listener<void>;
     // const onSuspendCanceled: Listener<void>;
     // const onBrowserUpdateAvailable: Listener<void>;
-    // const onConnectExternal: Listener<Port>;
-    // const onMessageExternal: Listener<any>;
     // const onRestartRequired: Listener<OnRestartRequiredReason>;
     const onUpdateAvailable: Listener<{ version: string }>;
     const onConnect: Listener<Port>;
+
+    const onConnectExternal: Listener<Port>;
 
     type onMessagePromise = (
         message: object,
@@ -752,6 +752,8 @@ declare namespace browser.runtime {
 
     type onMessageEvent = onMessagePromise | onMessageBool;
     const onMessage: EvListener<onMessageEvent>;
+
+    const onMessageExternal: EvListener<onMessageEvent>;
 }
 
 declare namespace browser.sidebarAction {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -298,6 +298,21 @@ declare namespace browser.cookies {
     const onChanged: Listener<{ removed: boolean, cookie: Cookie, cause: OnChangedCause }>;
 }
 
+declare namespace browser.devtools.inspectedWindow {
+    const tabId: number;
+
+    function eval(expression: string): Promise<[
+        any,
+        { isException: boolean, value: string } | { isError: boolean, code: string }
+    ]>;
+
+    function reload(reloadOptions?: {
+        ignoreCache?: boolean,
+        userAgent?: string,
+        injectedScript?: string,
+    }): void;
+}
+
 declare namespace browser.downloads {
     type FilenameConflictAction = "uniquify" | "overwrite" | "prompt";
 

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -317,6 +317,15 @@ declare namespace browser.devtools.network {
     const onNavigated: Listener<string>;
 }
 
+declare namespace browser.devtools.panels {
+    type ExtensionPanel = {
+        onShown: Listener<Window>,
+        onHidden: Listener<void>,
+    };
+
+    function create(title: string, iconPath: string, pagePath: string): Promise<ExtensionPanel>;
+}
+
 declare namespace browser.downloads {
     type FilenameConflictAction = "uniquify" | "overwrite" | "prompt";
 

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -313,6 +313,10 @@ declare namespace browser.devtools.inspectedWindow {
     }): void;
 }
 
+declare namespace browser.devtools.network {
+    const onNavigated: Listener<string>;
+}
+
 declare namespace browser.downloads {
     type FilenameConflictAction = "uniquify" | "overwrite" | "prompt";
 


### PR DESCRIPTION
### feat(webNavigation): add onCreatedNavigationTarget

Supported in FF54

### feat(runtime): support external events

As they are supported in FF54.

### feat(devtools): add inspectedWindow API

Integrated in FF54, has a few limitations still

### feat(devtools): network API completed

Only a single event is available

### feat(devtools): add the panels API

Small API, with a single function. The documentation is really crap
though, as the callback in events are not defined at all and had to be
found in chrome documentation

Which means that if FF does not follow the same API, this won't work