### PR TITLE
fix(runtime): enforce sendMessage different APIs

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -732,11 +732,24 @@ declare namespace browser.runtime {
         connectInfo?: { name?: string, includeTlsChannelId?: boolean }
     ): Port;
     function connectNative(application: string): Port;
+
     function sendMessage(
-        extensionId: string|null,
-        message: any,
-        options?: { includeTlsChannelId?: boolean }
+        message: any
     ): Promise<any>;
+    function sendMessage(
+        message: any,
+        options: { includeTlsChannelId?: boolean, toProxyScript?: boolean }
+    ): Promise<any>;
+    function sendMessage(
+        extensionId: string,
+        message: any,
+    ): Promise<any>;
+    function sendMessage(
+        extensionId: string,
+        message: any,
+        options?: { includeTlsChannelId?: boolean, toProxyScript?: boolean }
+    ): Promise<any>;
+
     function sendNativeMessage(
         application: string,
         message: object


### PR DESCRIPTION
As the function can have wildly different expectations and was clearly
not meant to be typed, enforce the contract by defining the function
with multiple types

Fix #28 