### PR TITLE
Added command param to contextMenus.create()

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -202,6 +202,7 @@ declare namespace browser.contextMenus {
         id?: string,
         title?: string,
         checked?: boolean,
+        command?: "_execute_browser_action" | "_execute_page_action" | "_excute_sidebar_action",
         contexts?: ContextType[],
         onclick?: (info: OnClickData, tab: browser.tabs.Tab) => void,
         parentId?: number|string,

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -202,7 +202,7 @@ declare namespace browser.contextMenus {
         id?: string,
         title?: string,
         checked?: boolean,
-        command?: "_execute_browser_action" | "_execute_page_action" | "_excute_sidebar_action",
+        command?: "_execute_browser_action" | "_execute_page_action" | "_execute_sidebar_action",
         contexts?: ContextType[],
         onclick?: (info: OnClickData, tab: browser.tabs.Tab) => void,
         parentId?: number|string,


### PR DESCRIPTION
Feature added by firefox 55, see https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextMenus/create