### PR TITLE
runtime.onMessage.addListener accepts void funcs

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -793,7 +793,13 @@ declare namespace browser.runtime {
         sendResponse: (response: object) => Promise<void>
     ) => boolean;
 
-    type onMessageEvent = onMessagePromise | onMessageBool;
+    type onMessageVoid = (
+        message: object,
+        sender: MessageSender,
+        sendResponse: (response: object) => Promise<void>
+    ) => void;
+
+    type onMessageEvent = onMessagePromise | onMessageBool | onMessageVoid;
     const onMessage: EvListener<onMessageEvent>;
 
     const onMessageExternal: EvListener<onMessageEvent>;


### PR DESCRIPTION
This is not clearly documented, but is in clear use in many
webextensions and in internal firefox code[1].

[1]: http://searchfox.org/mozilla-central/search?q=onMessage.addListener&case=true&path=*extension