### PR TITLE
`StorageArea.get` returns typed object when object is passed in parameter

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -834,8 +834,13 @@ declare namespace browser.storage {
         [key: string]: any
     }
 
+    interface Get {
+        (keys: string|string[]|null): Promise<StorageResults>;
+        <T>(keys: T): Promise<T>;
+    }
+
     type StorageArea = {
-        get: (keys: string|string[]|object|null) => Promise<StorageResults>,
+        get: Get,
         // unsupported: getBytesInUse: (keys: string|string[]|null) => Promise<number>,
         set: (keys: object) => Promise<void>,
         remove: (keys: string|string[]) => Promise<void>,

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -836,7 +836,7 @@ declare namespace browser.storage {
 
     interface Get {
         (keys: string|string[]|null): Promise<StorageResults>;
-        <T>(keys: T): Promise<T>;
+        <T extends object>(keys: T): Promise<{[K in keyof T]: T[K]}>;
     }
 
     type StorageArea = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web-ext-types",
     "author": "Michael Zapata <michael.zapata@scality.com> (https://github.com/michael-zapata)",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "TypeScript type definitions for WebExtensions",
     "keywords": ["firefox", "typescript", "webextension"],
     "repository": "michael-zapata/web-ext-types",


### PR DESCRIPTION
In the [MDN page for `StorageArea.get`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/StorageArea/get) it is stated that:

> A Promise that will be fulfilled with a results object containing every object in keys that was found in the storage area.

So for the `string`, `string[]` or `null` parameter it is impossible to know the type, if an object is used it is the same type that will be returned.

I am new to typescript but I think that the use of `interface` to declare the overloads of `get` is the right way to do that.

I haven't found any tests, by I use this modification in my current in-dev project of web-extension and it is working great.