### PR TITLE
matchAboutBlank is now supported

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -502,7 +502,7 @@ declare namespace browser.extensionTypes {
         code?: string,
         file?: string,
         frameId?: number,
-        // unsupported: matchAboutBlank?: boolean,
+        matchAboutBlank?: boolean,
         runAt?: RunAt,
     };
 }


### PR DESCRIPTION
As stated on [MDN](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/executeScript#Browser_compatibility).