### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.tgz
+*.log


### PR DESCRIPTION
You probably add `node_modules/` in a global `.gitignore`, but this is really a bad practice to use it for excluding folders like that.
A nice use of global `.gitignore` is to ignore IDE-specific folders, like `.idea/` for IntelliJ IDEA or `.vscode` for VS Code.