### PR TITLE
add sidebarAction.isOpen

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1467,7 +1467,7 @@ declare namespace browser.sidebarAction {
 
   function close(): Promise<void>;
 
-  function isOpen(): Promise<boolean>;
+  function isOpen(details: { windowId?: number }): Promise<boolean>;
 }
 
 declare namespace browser.storage {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1466,6 +1466,8 @@ declare namespace browser.sidebarAction {
   function open(): Promise<void>;
 
   function close(): Promise<void>;
+
+  function isOpen(): Promise<boolean>;
 }
 
 declare namespace browser.storage {

--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -1467,6 +1467,8 @@ declare namespace browser.sidebarAction {
 
   function close(): Promise<void>;
 
+  function toggle(): Promise<void>;
+
   function isOpen(details: { windowId?: number }): Promise<boolean>;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-ext-types",
   "author": "Kelsey Zapata <key@kelseasy.org> (https://kelseyz.org)",
-  "version": "3.2.1",
+  "version": "3.3.1",
   "description": "TypeScript type definitions for WebExtensions",
   "keywords": [
     "firefox",


### PR DESCRIPTION
Thanks for getting this project @kelseasy: `sidebarAction.isOpen` is part of the API but not part of the definition (see this below):

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/isOpen